### PR TITLE
fix shade of auth, chdfs and httpcomments and use the head bucket to distinguish POSIX bucket auto

### DIFF
--- a/flink-cos-fs-base/pom.xml
+++ b/flink-cos-fs-base/pom.xml
@@ -19,9 +19,9 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <fs.cos.sdk.version>5.6.69</fs.cos.sdk.version>
-        <fs.ofs.sdk.version>2.8</fs.ofs.sdk.version>
-        <fs.cosn.version>8.1.4</fs.cosn.version>
+        <fs.cos.sdk.version>5.6.112</fs.cos.sdk.version>
+        <fs.ofs.sdk.version>3.1</fs.ofs.sdk.version>
+        <fs.cosn.version>8.2.3</fs.cosn.version>
         <gson.version>2.8.5</gson.version>
     </properties>
 
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.qcloud</groupId>
             <artifactId>ofs-sdk-definition</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.4</version>
         </dependency>
 
         <dependency>

--- a/flink-cos-fs-base/src/main/java/org/apache/flink/fs/cos/common/writer/COSAccessHelper.java
+++ b/flink-cos-fs-base/src/main/java/org/apache/flink/fs/cos/common/writer/COSAccessHelper.java
@@ -73,4 +73,6 @@ public interface COSAccessHelper {
     long getObject(String key, File targetLocation) throws IOException;
 
     FileMetadata getObjectMetadata(String key) throws IOException;
+
+    boolean isPosixBucket();
 }

--- a/flink-cos-fs-hadoop/pom.xml
+++ b/flink-cos-fs-hadoop/pom.xml
@@ -68,6 +68,12 @@
                                     <shadedPattern>${hadoop.shading.prefix}.org.apache.hadoop</shadedPattern>
                                 </relocation>
 -->
+                                <!-- used by ranger to load provider class, which must test for other provider -->
+                                <relocation>
+                                    <pattern>org.apache.hadoop.fs.auth</pattern>
+                                    <shadedPattern>${hadoop.shading.prefix}.org.apache.hadoop.fs.auth</shadedPattern>
+                                </relocation>
+
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>${hadoop.shading.prefix}.org.apache.commons</shadedPattern>
@@ -82,7 +88,7 @@
                                     <shadedPattern>${cos.shading.prefix}.shaded.com.qcloud</shadedPattern>
                                     <excludes>
                                         <!-- avoid relocate fs lock class cause network can not load real jar-->
-                                        <exclude>com.qcloud.chdfs.*</exclude>
+                                        <exclude>com.qcloud.chdfs.**</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>

--- a/flink-cos-fs-hadoop/src/main/java/org/apache/flink/fs/coshadoop/HadoopCOSAccessHelper.java
+++ b/flink-cos-fs-hadoop/src/main/java/org/apache/flink/fs/coshadoop/HadoopCOSAccessHelper.java
@@ -107,4 +107,9 @@ public class HadoopCOSAccessHelper implements COSAccessHelper {
             throw new FileNotFoundException("No such file for the key '" + key + "'");
         }
     }
+
+    @Override
+    public boolean isPosixBucket() {
+        return this.store.isPosixBucket();
+    }
 }

--- a/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-fs-hadoop-shaded/pom.xml
@@ -44,10 +44,12 @@
                             <groupId>xmlenc</groupId>
                             <artifactId>xmlenc</artifactId>
                         </exclusion>
+                        <!-- chdfs network use the httpcommonents content but provided, after 2.9 version.
                         <exclusion>
                             <groupId>org.apache.httpcomponents</groupId>
                             <artifactId>httpclient</artifactId>
                         </exclusion>
+                        -->
                         <exclusion>
                             <groupId>commons-net</groupId>
                             <artifactId>commons-net</artifactId>
@@ -182,10 +184,12 @@
                             <groupId>org.apache.commons</groupId>
                             <artifactId>commons-math3</artifactId>
                         </exclusion>
+                        <!-- chdfs network use the httpcommonents content but provided, after 2.9 version.
                         <exclusion>
                             <groupId>org.apache.httpcomponents</groupId>
                             <artifactId>httpclient</artifactId>
                         </exclusion>
+                        -->
                         <exclusion>
                             <groupId>commons-net</groupId>
                             <artifactId>commons-net</artifactId>


### PR DESCRIPTION
1) fix the shade of httpcomments and use the head bucket to distinguish POSIX bucket auto
2) add ranger shade and fix exclude of file system lock